### PR TITLE
Make workouts time zone aware

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -229,6 +229,9 @@
                 <version>6.5.3</version>
                 <configuration>
                     <url>${env.JDBC_DATABASE_URL}</url>
+                    <locations>
+                        <location>classpath:db/migration</location>
+                    </locations>
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/backend/src/main/kotlin/db/migration/V6__MakeWorkoutsTimeZoneAware.kt
+++ b/backend/src/main/kotlin/db/migration/V6__MakeWorkoutsTimeZoneAware.kt
@@ -1,0 +1,56 @@
+package db.migration
+
+import dev.anthonybruno.gymbuddy.db.DefaultJdbcHelper
+import org.flywaydb.core.api.migration.BaseJavaMigration
+import org.flywaydb.core.api.migration.Context
+import java.sql.Timestamp
+import java.time.Instant
+import java.time.ZoneId
+
+class V6__MakeWorkoutsTimeZoneAware : BaseJavaMigration() {
+
+    override fun migrate(context: Context) {
+        val helper = DefaultJdbcHelper(context.configuration.dataSource)
+
+        // Firstly, let's get all users and their timezone
+        val records = helper.query({ conn ->
+            conn.prepareStatement("""
+                SELECT u.id, u.timezone
+                FROM users u;
+                """)
+        }, { rs, ctx ->
+            Record(rs.getLong("id"), rs.getString("timezone"))
+        })
+
+        // Next, we update each workout with timezone information
+        records.forEach { r ->
+            helper.execute {
+                it.prepareStatement("""
+                   UPDATE workouts
+                   SET timezone = ?
+                   WHERE user_id = ?
+                """).apply {
+                    setString(1, r.timeZoneStr)
+                    setLong(2, r.userId)
+                }
+            }
+        }
+
+        // Finally, we can drop the old date column and replace it with date_tz
+        helper.execute {
+            it.prepareStatement("""
+                ALTER TABLE workouts
+                DROP COLUMN date;
+
+                ALTER TABLE workouts
+                RENAME COLUMN date_tz to date;
+            """)
+        }
+    }
+}
+
+private class Record(val userId: Long, val timeZoneStr: String) {
+
+    val timezone = ZoneId.of(timeZoneStr)
+
+}

--- a/backend/src/main/kotlin/dev/anthonybruno/gymbuddy/Server.kt
+++ b/backend/src/main/kotlin/dev/anthonybruno/gymbuddy/Server.kt
@@ -38,7 +38,8 @@ class Server(private val database: Database) {
     }
 
     private fun runMigrations() {
-        val flyway = Flyway.configure().dataSource(database.toDataSource()).load()
+        val flyway = Flyway.configure()
+                .dataSource(database.toDataSource()).load()
         flyway.migrate()
     }
 

--- a/backend/src/main/resources/db/migration/V5__add-timezone-aware-columns.sql
+++ b/backend/src/main/resources/db/migration/V5__add-timezone-aware-columns.sql
@@ -1,0 +1,21 @@
+-- Previously, we were using TIMESTAMP in the date column in workouts. This has the problem that it drops timezone
+-- information. For instance, storing "11/02/2020 5PM +3 GMT" would become "11/02/2020 5PM", which is the equivalent
+-- of storing a LocalDateTime
+
+-- We want to adjust the current date column to use TIMESTAMP WITH TIME ZONE, which coverts dates into UTC to store
+-- them. In the above example storing "11/02/2020 5PM +3 GMT" would become "11/02/2020 2PM UTC".
+
+-- We have been converting to UTC time in the application level, but we want to play it safe and ensure the db
+-- is storing the correct data. Also, this would open up functionality of a user being able to add a workout
+-- that is in a different time zone to their normal one, and display it appropriately in the UI.
+
+-- The data migration itself is handled in V6__MakeWorkoutsTimeZoneAware.kt
+
+ALTER TABLE users
+    ADD COLUMN timezone text NOT NULL default 'Australia/Adelaide';
+
+ALTER TABLE workouts
+    ADD COLUMN date_tz TIMESTAMP WITH TIME ZONE;
+
+ALTER TABLE workouts
+    ADD COLUMN timezone text;


### PR DESCRIPTION
Previously, we were using TIMESTAMP in the date column in workouts. This has the problem that it drops timezone
information. For instance, storing "11/02/2020 5PM +3 GMT" would become "11/02/2020 5PM", which is the equivalent
of storing a LocalDateTime.

We want to adjust the current date column to use TIMESTAMP WITH TIME ZONE, which coverts dates into UTC to store
them. In the above example storing "11/02/2020 5PM +3 GMT" would become "11/02/2020 2PM UTC".

We have been converting to UTC time in the application level, but we want to play it safe and ensure the db
is storing the correct data. Also, this would open up functionality of a user being able to add a workout
that is in a different time zone to their normal one, and display it appropriately in the UI.