### PR TITLE
Use plotly.js-basic-dist instead of dist

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9098,6 +9098,11 @@
         "find-up": "^3.0.0"
       }
     },
+    "plotly.js-basic-dist": {
+      "version": "1.55.2",
+      "resolved": "https://registry.npmjs.org/plotly.js-basic-dist/-/plotly.js-basic-dist-1.55.2.tgz",
+      "integrity": "sha512-ooEC7kYBlreylSG7/avnOK8S036tbWlfxiS32o60M4cgo9roraNlMqv6+9GZRfJTprn+faECU/k8iBGMkiK7Mw=="
+    },
     "plotly.js-dist": {
       "version": "1.55.2",
       "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-1.55.2.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "@types/react-router-dom": "^5.1.5",
     "bootstrap": "^4.5.2",
     "date-fns": "^2.14.0",
-    "plotly.js-dist": "^1.55.2",
+    "plotly.js-basic-dist": "^1.55.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.2.0",

--- a/frontend/src/components/Graph.tsx
+++ b/frontend/src/components/Graph.tsx
@@ -1,4 +1,4 @@
-import Plotly, {Config, Data, Layout} from 'plotly.js-dist'
+import Plotly, {Config, Data, Layout} from 'plotly.js-basic-dist'
 import React, {useEffect, useRef} from "react"
 
 export interface GraphProps {

--- a/frontend/tspaths.json
+++ b/frontend/tspaths.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "plotly.js-dist": [
+      "plotly.js-basic-dist": [
         "node_modules/@types/plotly.js"
       ]
     }


### PR DESCRIPTION
Something about CRA + plotly.js means that the chance of `npm run build` finishing is low. Moving to basic-dist seems to have solved the issue for now, but need to work out what the actual problem is.

https://github.com/plotly/react-plotly.js/issues/135